### PR TITLE
fix(docker): kjør prisma migrate deploy ved oppstart

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,13 +37,35 @@ RUN addgroup -S app && adduser -S app -G app
 COPY --from=builder --chown=app:app /build/.next/standalone ./
 COPY --from=builder --chown=app:app /build/.next/static ./.next/static
 
+# Skjemaet og migrasjonene, så containeren kan migrere seg selv ved oppstart.
+COPY --from=builder --chown=app:app /build/prisma ./prisma
+
+# Prisma-CLI-en globalt i stedet for kopiert fra deps-steget: pnpm lager
+# symlenker inn i .pnpm-mappa, og de overlever ikke en COPY --from.
+# Samme versjon som pnpm-lock.yaml låser.
+RUN npm i -g prisma@6.16.3
+
+RUN rm -f .env* || true
+
+# Kjører migrasjonene før serveren starter.
+#
+# Verken deploy.yml eller Drift gjør det: workflowen bygger imaget og varsler,
+# og Drift henter og starter det. `prisma migrate deploy` fantes bare i
+# deploy.sh, som er den manuelle veien. Da PhotonSession kom med
+# Photon-innloggingen, ble tabellen derfor aldri opprettet i prod, og
+# innloggingen stoppet stille i callbacket.
+#
+# `migrate deploy` kjører bare migrasjoner som mangler, og er en no-op når alt
+# er på plass — trygt på hver eneste oppstart.
+COPY --chown=app:app docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
 USER app
 
 ENV NODE_ENV=production
 
 EXPOSE 3000
 
-RUN rm -f .env* || true
-
+ENTRYPOINT [ "/usr/local/bin/docker-entrypoint.sh" ]
 CMD [ "node", "server.js" ]
 

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+set -e
+
+# Migrer før serveren tar imot trafikk.
+#
+# `migrate deploy` kjører bare det som mangler og er en no-op ellers, så dette
+# koster et par sekunder på en oppstart der alt allerede er på plass.
+#
+# Feiler migrasjonen, stopper vi. En app som kjører mot et skjema den ikke
+# forventer feiler uansett — men da én forespørsel om gangen, på et tidspunkt
+# ingen kobler til deployet.
+echo "-> prisma migrate deploy"
+prisma migrate deploy
+
+echo "-> starter appen"
+exec "$@"


### PR DESCRIPTION
Prod står på `20260216171534_add_bookable_item_image_url`. Migrasjonen som fulgte med Photon-innloggingen har aldri kjørt, så `PhotonSession`-tabellen finnes ikke.

```
 migration_name                             | ok
--------------------------------------------+----
 20250303161424_initial                     | t
 20250911223513_refactored_groups           | t
 20260216171534_add_bookable_item_image_url | t
(20260812180000_photon_session mangler)
```

## Hvorfor

Ingenting kjører migrasjonene. `deploy.yml` bygger imaget og varsler Drift, Drift henter og starter det, og Dockerfile-ens `CMD` er bare `node server.js`. `prisma migrate deploy` fantes kun i `deploy.sh` — den manuelle veien, som ikke er det som kjører.

Det gikk bra så lenge ingen migrasjon kom. Nå gjør det ikke det: innloggingen kommer seg gjennom Photon, men callbacket feiler på en tabell som ikke finnes. `jwt`-callbacken fanger feilen og returnerer `null`, så brukeren havner tilbake på innloggingssiden uten at noe forklarer hvorfor.

## Fiksen

Et entrypoint som kjører `prisma migrate deploy` før serveren starter. `migrate deploy` kjører bare det som mangler og er en no-op ellers, så det er trygt på hver oppstart.

Prisma-CLI-en installeres globalt i runner-steget i stedet for å kopieres fra `deps`: pnpm lager symlenker inn i `.pnpm`, og de overlever ikke en `COPY --from`.

Feiler migrasjonen, stopper oppstarten. En app som kjører mot et uventet skjema feiler uansett — men da én forespørsel om gangen, på et tidspunkt ingen kobler til deployet.

## Verifisert

Mot en base satt tilbake til nøyaktig prods tilstand (droppet tabellen, fjernet migrasjonsraden):

```
-> prisma migrate deploy
4 migrations found in prisma/migrations
Applying migration `20260812180000_photon_session`
All migrations have been successfully applied.
-> starter appen
 ✓ Ready in 168ms
```

Tabellen ble opprettet, appen svarte 200 på `/login`, og en omstart etterpå ga «No pending migrations to apply».

🤖 Generated with [Claude Code](https://claude.com/claude-code)