### PR TITLE
fix(login): ta innloggingsknappen ut av server action

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,7 +1,7 @@
-import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 
-import { auth, signIn } from '@/auth';
+import { TihldeSignInButton } from './tihlde-sign-in-button';
+import { auth } from '@/auth';
 import { redirect } from 'next/navigation';
 
 /**
@@ -37,16 +37,7 @@ export default async function Page(props: {
                             Innloggingen ble avbrutt. Prøv på nytt.
                         </p>
                     ) : null}
-                    <form
-                        action={async () => {
-                            'use server';
-                            await signIn('tihlde', { redirectTo: redirectUrl });
-                        }}
-                    >
-                        <Button className="w-full" type="submit">
-                            Logg inn med TIHLDE
-                        </Button>
-                    </form>
+                    <TihldeSignInButton redirectTo={redirectUrl} />
                 </CardContent>
             </Card>
         </div>

--- a/src/app/login/tihlde-sign-in-button.tsx
+++ b/src/app/login/tihlde-sign-in-button.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+
+import { signIn } from 'next-auth/react';
+import { useState } from 'react';
+
+/**
+ * Innloggingsknappen, med vilje som klientkall og ikke som server action.
+ *
+ * Server actions får en id av en build-hash. En fane som ble åpnet før en
+ * deploy sitter dermed med en id som ikke finnes etterpå, og klikket svarer
+ * «Failed to find Server Action» — som Next.js viser som en blank
+ * «Something went wrong». Brukeren kommer da aldri av gårde til tihlde.org,
+ * og siden Kontres deployer ofte, traff det nettopp den ene knappen som må
+ * virke. Vi så ni slike i loggene på fire døgn.
+ *
+ * `signIn` fra next-auth/react henter CSRF-token selv og poster til
+ * `/api/auth/signin/tihlde`. Den ruta er den samme på tvers av deploys, så en
+ * gammel fane fungerer like godt som en fersk.
+ */
+export function TihldeSignInButton({ redirectTo }: { redirectTo: string }) {
+    const [sending, setSending] = useState(false);
+
+    return (
+        <Button
+            className="w-full"
+            disabled={sending}
+            onClick={() => {
+                setSending(true);
+                // Lykkes den, forlater vi siden uansett. Feiler den, er det
+                // eneste rimelige å la brukeren prøve igjen.
+                void signIn('tihlde', { redirectTo }).catch(() =>
+                    setSending(false),
+                );
+            }}
+        >
+            {sending ? 'Sender deg til TIHLDE …' : 'Logg inn med TIHLDE'}
+        </Button>
+    );
+}


### PR DESCRIPTION
## Symptomet

Hvit skjerm med «Something went wrong» når du trykker «Logg inn med TIHLDE». Du kommer aldri videre til tihlde.org.

## Årsaken

Knappen var en server action. Next.js gir server actions en id som stammer fra en build-hash, så en fane som ble åpnet før en deploy sitter igjen med en id som ikke finnes etterpå:

```
Failed to find Server Action "x". This request might be from an older or newer deployment.
```

Next.js viser det som en blank «Something went wrong». Kontres deployer ofte og folk lar fanen ligge, så det traff nettopp den ene knappen som må virke.

**Ni forekomster i loggene på fire døgn.** Til sammenlikning: 0 `PhotonUnavailable` og 0 `refresh failed` i samme periode.

## Fiksen

`signIn` fra `next-auth/react` i en liten klientkomponent. Den henter CSRF-token selv og poster til `/api/auth/signin/tihlde` — en rute som er den samme på tvers av deploys. En gammel fane fungerer da like godt som en fersk.

## Verifisert

Kjørt lokalt mot ekte Photon. Klikk på knappen gir nøyaktig:

```
GET  /api/auth/providers      200
GET  /api/auth/csrf           200
POST /api/auth/signin/tihlde  200
```

og nettleseren havner på `photon.tihlde.org`. Ingen server action involvert, ingen «Something went wrong».

Lokalt avviser Photon runden med `invalid_redirect`, siden bare produksjons-URI-en er registrert — det skjer *etter* at knappen har gjort jobben sin, og er forventet utenfor prod.

`pnpm build` grønn. `pnpm typecheck` gir de samme 6 forhåndseksisterende feilene som `master` — ingen nye.

## Merk

Dette er den faktiske årsaken til hvitskjermen. #200 fikset en ekte, men **latent** bug i tokenfornyelsen som aldri har fyrt i prod (0 treff i loggene) — den er riktig herding, men feil diagnose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)