### PR TITLE
fix(auth): send foreldede innloggingskapsler til innlogging, ikke til kræsj

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -21,7 +21,19 @@ export const middleware = auth((req) => {
     if (path.startsWith('/trpc')) return;
 
     console.log('[MIDDLEWARE] Checking logged in state for:', path);
-    const isLoggedIn = !!req.auth;
+    /**
+     * `photonSessionId` må være med, ikke bare en gyldig informasjonskapsel.
+     *
+     * Uten `jwt`-callbacken ser mellomvaren bare at kapselen er signert og
+     * ikke utløpt. Kapsler fra før Photon-innloggingen passerer den testen —
+     * de har `user`, men ingen `photonSessionId` — og lever i tretti dager til.
+     * Serveren kjører callbacken, får `null`, og hver serverkomponent som
+     * spør etter økta feiler: `/booking` kaster `UNAUTHORIZED` og medlemmet
+     * får «Kræsj, pang, bom» i stedet for innloggingssiden.
+     *
+     * Feltet ligger allerede i JWT-en, så dette koster ikke et oppslag.
+     */
+    const isLoggedIn = !!req.auth?.photonSessionId;
     if (!isLoggedIn) {
         const redirectUrl = new URL('/login', req.url);
         redirectUrl.searchParams.set(


### PR DESCRIPTION
## Hva som er galt

Evine fikk «Kræsj, pang, bom» da hun ville se bookinger i kveld. I loggene ligger det fem `TRPCError: UNAUTHORIZED` på `/booking` 15. august — de første av sitt slag på tretti dager.

Mellomvaren sa `[MIDDLEWARE] User is logged in` rett før hver eneste av dem.

## Hvorfor

`middleware.ts` bygger en egen NextAuth-instans uten `jwt`-callbacken. Det er med vilje — kommentaren i fila forklarer at to kopier ellers ville fornyet med det samme refresh-tokenet, og Photon leser andre gangs bruk som tyveri. Men konsekvensen er at mellomvaren bare sjekker at informasjonskapselen er signert og ikke utløpt.

Kapsler fra før Photon-innloggingen (`0e76937`, 12. aug) består den testen. De har `user`, men ingen `photonSessionId`, og `session: { strategy: 'jwt' }` uten `maxAge` gir NextAuth-standarden på tretti dager. Så:

1. Mellomvaren: gyldig kapsel → slipper inn på `/booking`
2. Serveren kjører callbacken → `!sessionId` → `auth()` gir `null`
3. `memberProcedure` → `UNAUTHORIZED` → `error.tsx`

Det stemmer med loggen: ved den første feilen ble det ikke gjort noe token-kall mot Photon i det hele tatt. Koden rakk aldri dit.

Verifisert mot basene: Evine har nøyaktig én `PhotonSession`-rad og ett refresh-token hos Photon, begge opprettet 20:23:45 — sju sekunder **etter** feilene hennes. Hun hadde aldri logget inn mot Photon på KontRes før i kveld.

Bare fem personer har noensinne logget inn via Photon her. Alle andre bærer fortsatt en kapsel fra Lepton-tiden, og ville fått samme kræsj.

## Fiksen

```ts
const isLoggedIn = !!req.auth?.photonSessionId;
```

`photonSessionId` legges på økta av `session`-callbacken i den delte `authConfig`, så feltet er allerede tilgjengelig i mellomvaren. Ingen oppslag, ingen fornyelse, ingen risiko for dobbel bruk av refresh-tokenet.

## Verifisert

Bygde både `master` og denne greina, startet dem med en kunstig kapsel som har `user` men ingen `photonSessionId`:

| | `master` | denne greina |
|---|---|---|
| gammel kapsel på `/booking` | `200/500` — mellomvaren sa «User is logged in», sida kjørte og feilet | **307 → `/login?redirect=%2Fbooking`** |
| kapsel med `photonSessionId` | slipper forbi | slipper forbi (uendret) |
| ingen kapsel | 307 → `/login` | 307 → `/login` (uendret) |

`pnpm build` grønn. `pnpm typecheck` og `pnpm lint` har samme feil som `master` fra før (6 typefeil, ingen i `middleware.ts`) — ingen nye.

🤖 Generated with [Claude Code](https://claude.com/claude-code)