### PR TITLE
ci: kjør typecheck, lint og build på pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: "typecheck -> lint -> build"
+
+# Sjekkene som ikke fantes fra før. `deploy.yml` fyrer bare på push til
+# master, så ingenting kjørte på en pull request — derfor sto master rød på
+# seks typefeil og 67 lint-feil uten at noen så det.
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    # `next.config.js` importerer `src/env.js`, så både lint og build laster
+    # env-skjemaet og faller på manglende hemmeligheter. Sjekkene trenger dem
+    # ikke — de skal bare vite at koden kompilerer. Samme flagg som Dockerfile.
+    env:
+      SKIP_ENV_VALIDATION: 1
+
+    steps:
+      - uses: actions/checkout@v6
+
+      # Leser versjonen fra `packageManager` i package.json, så den ikke kan
+      # komme ut av synk slik den gjorde i Dockerfile.
+      - uses: pnpm/action-setup@v4
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # `postinstall` kjører `prisma generate`, som typecheck og build trenger.
+      - run: pnpm install --frozen-lockfile
+
+      # Alle tre kjører selv om en av dem feiler, så én kjøring viser hele
+      # bildet i stedet for én feil om gangen.
+      - name: Typecheck
+        if: ${{ !cancelled() }}
+        run: pnpm typecheck
+
+      - name: Lint
+        if: ${{ !cancelled() }}
+        run: pnpm lint
+
+      - name: Build
+        if: ${{ !cancelled() }}
+        run: pnpm build


### PR DESCRIPTION
Repoet hadde ingen CI på pull requests. `deploy.yml` er eneste workflow og fyrer bare på push til `master`, så ingenting sjekket at koden kompilerte før den ble merget. Det er derfor `master` sto rød på seks typefeil (#207) og 67 lint-feil (#209) uten at noen så det.

## Hva den gjør

Én jobb, tre steg: `pnpm typecheck`, `pnpm lint`, `pnpm build`. Kjøres på hver pull request og på push til `master`.

Hvert steg har `if: ${{ !cancelled() }}`, så alle tre kjører selv om et av dem feiler — én kjøring viser hele bildet i stedet for én feil om gangen.

## To detaljer som ikke er selvsagte

**`SKIP_ENV_VALIDATION` settes på jobben, ikke bare på bygget.** `next.config.js` importerer `src/env.js`, så også `next lint` laster env-skjemaet og dør på `Error: Invalid environment variables` uten hemmeligheter. Jeg oppdaget det ved å flytte `.env` bort og kjøre sjekkene — ellers hadde workflowen vært rød på første kjøring. Sjekkene trenger ingen ekte verdier; de skal bare vite at koden kompilerer. Samme flagg som Dockerfile bruker.

**pnpm-versjonen leses fra `packageManager`.** `pnpm/action-setup@v4` plukker den opp fra package.json av seg selv, så den ikke kan drive fra hverandre — nettopp den driften låste deployet fra 19. mai til 12. august.

## Verifisert

Flyttet `.env` bort og kjørte `SKIP_ENV_VALIDATION=1 pnpm typecheck && pnpm lint && pnpm build` — alle tre grønne uten en eneste hemmelighet tilgjengelig. `.env` lagt tilbake uendret etterpå.

Kjøringen på denne PR-en er samtidig den første ekte testen av workflowen.

## Verdt å vurdere etterpå

Hvis dere gjør `check` til en påkrevd status i branch protection, kan ikke en rød `master` skje igjen. Det er en innstilling i repoet, ikke noe jeg kan sette i en PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)